### PR TITLE
Fix get-version for mysql to order by descending version, rather than…

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject cc.artifice/lein-tern "0.2.2"
+(defproject cc.artifice/lein-tern "0.2.3"
   :description "Migrations as data"
   :url "http://github.com/artifice-cc/lein-tern"
   :license {:name "MIT"

--- a/src/tern/mysql.clj
+++ b/src/tern/mysql.clj
@@ -137,7 +137,7 @@
     (jdbc/query
       (db-spec db)
       [(format "SELECT version FROM %s
-               ORDER BY created DESC
+               ORDER BY version DESC
                LIMIT 1" version-table)]
       :row-fn :version
       :result-set-fn first)))
@@ -155,9 +155,9 @@
     (let [sql-commands (into [] (mapcat generate-sql commands))]
       (log/info "Running: " sql-commands)
       (apply jdbc/db-do-commands
-             (db-spec db)
-             (conj sql-commands
-                   (update-schema-version version-table version))))))
+							             (db-spec db)
+							             (conj sql-commands
+							                   (update-schema-version version-table version))))))
 
 (defn- validate-commands
   [commands]

--- a/src/tern/version.clj
+++ b/src/tern/version.clj
@@ -1,2 +1,2 @@
 (ns tern.version)
-(def tern-version "0.2.2")
+(def tern-version "0.2.3")


### PR DESCRIPTION
Updates mysql's get-version to order by descending version rather than by descending created, since the latter <<seems>> to compare only dates, and not times. The behavior was seemingly random when applied to a new repository that had had many migrations processed within a second.
