### PR TITLE
Support foreign key constraints in create-table, add/drop foreign key constraints in alter-table

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject cc.artifice/lein-tern "0.2.3"
+(defproject cc.artifice/lein-tern "0.2.4"
   :description "Migrations as data"
   :url "http://github.com/artifice-cc/lein-tern"
   :license {:name "MIT"

--- a/src/tern/version.clj
+++ b/src/tern/version.clj
@@ -1,2 +1,2 @@
 (ns tern.version)
-(def tern-version "0.2.3")
+(def tern-version "0.2.4")

--- a/test/tern/mysql_test.clj
+++ b/test/tern/mysql_test.clj
@@ -1,0 +1,17 @@
+(ns tern.mysql-test
+  (:require [tern.mysql   :refer :all]
+            [expectations :refer :all]))
+
+(expect ["CREATE TABLE foo (a INT)"]
+        (generate-sql {:create-table :foo :columns [[:a "INT"]]}))
+
+(expect ["CREATE TABLE foo (a INT, PRIMARY KEY (a))"]
+        (generate-sql {:create-table :foo :columns [[:a "INT"]] :primary-key [:a]}))
+
+(expect ["CREATE TABLE foo (a INT, CONSTRAINT fk_a FOREIGN KEY (a) REFERENCES foo(a))"]
+        (generate-sql {:create-table :foo :columns [[:a "INT"]] :constraints [[:fk_a "(a) REFERENCES foo(a)"]]}))
+
+(expect ["CREATE TABLE foo (a INT, PRIMARY KEY (a), CONSTRAINT fk_a FOREIGN KEY (a) REFERENCES foo(a))"]
+        (generate-sql {:create-table :foo :columns [[:a "INT"]] :primary-key [:a] :constraints [[:fk_a "(a) REFERENCES foo(a)"]]}))
+
+


### PR DESCRIPTION
You can think about this one.  To support some changes to the DB schema, I had no choice but to implement support for dropping foreign key constraints (because they were part of the original DB schema before migrations, and couldn't make alterations to the table without being able to drop the constraint).  So I added support for adding foreign key constraints, both in :alter-table and in :create-table commands.

I added a mysql_test.clj file that at least verifies the expected behavior for the changes I made.
