### PR TITLE
Progress towards idempotency

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject cc.artifice/lein-tern "0.3.0"
+(defproject cc.artifice/lein-tern "0.4.0"
   :description "Migrations as data"
   :url "http://github.com/artifice-cc/lein-tern"
   :license {:name "MIT"

--- a/src/tern/mysql.clj
+++ b/src/tern/mysql.clj
@@ -6,6 +6,10 @@
   (:import [java.util Date]
            [java.sql PreparedStatement Timestamp]))
 
+(declare foreign-key-exists?)
+
+(def ^:dynamic *db* nil)
+
 (def ^{:doc "Set of supported commands. Used in `generate-sql` dispatch."
        :private true}
   supported-commands
@@ -75,29 +79,25 @@
                       (s/join " " specs))))
         new-constraints
         (for [[constraint & specs] add-constraints]
-          (let [test (format (str "IF NOT EXISTS (SELECT 1 FROM information_schema.TABLE_CONSTRAINTS WHERE "
-                                  "CONSTRAINT_SCHEMA=DATABASE() AND "
-                                  "CONSTRAINT_NAME='%s' AND "
-                                  "CONSTRAINT_TYPE='FOREIGN KEY') THEN")
-                             (to-sql-name constraint))]
-            (log/info "    * Adding constraint " (log/highlight (if constraint constraint "unnamed")))
-            (format "%s ALTER TABLE %s ADD CONSTRAINT %s FOREIGN KEY %s" 
-                    test (to-sql-name table)
-                    (to-sql-name constraint)
-                    (s/join  " " specs))))
+          (if (not (foreign-key-exists? *db* (to-sql-name constraint)))
+            (do
+              (log/info "    * Adding constraint " (log/highlight (if constraint constraint "unnamed")))
+              (format "ALTER TABLE %s ADD CONSTRAINT %s FOREIGN KEY %s" 
+                      (to-sql-name table)
+                      (to-sql-name constraint)
+                      (s/join  " " specs)))
+            (log/info "    * Skipping adding constraint " (log/highlight (if constraint constraint "unnamed"))
+                      " because it already exists")))
        old-constraints
        (for [constraint drop-constraints]
-         (let [test (format (str "IF EXISTS (SELECT 1 FROM information_schema.TABLE_CONSTRAINTS WHERE "
-                                  "CONSTRAINT_SCHEMA=DATABASE() AND "
-                                  "CONSTRAINT_NAME='%s' AND "
-                                  "CONSTRAINT_TYPE='FOREIGN KEY') THEN")
-                             (to-sql-name constraint))]
-           (log/info "    * Removing constraint " (log/highlight constraint))
-           (format "%s ALTER TABLE %s DROP FOREIGN KEY %s",
-                   test
-                   (to-sql-name table)
-                   (to-sql-name constraint))))]
-    (doall (concat old-constraints removals additions modifications new-constraints))))
+         (if (foreign-key-exists? *db* (to-sql-name constraint))
+           (do
+             (log/info "    * Removing constraint " (log/highlight constraint))
+             (format "ALTER TABLE %s DROP FOREIGN KEY %s",
+                     (to-sql-name table)
+                     (to-sql-name constraint)))
+           (log/info "   * Skipping removing constraint " (log/highlight constraint) " because it does not exist")))]
+    (doall (filter identity (concat old-constraints removals additions modifications new-constraints)))))
 
 (defmethod generate-sql
   :create-index
@@ -137,6 +137,16 @@
     (db-spec db "mysql")
     ["SELECT 1 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = ?" (:database db)]
     :result-set-fn first))
+
+(defn- foreign-key-exists?
+  [db fk]
+  (if db
+    (jdbc/query
+     (db-spec db)
+     ["SELECT 1 from information_schema.table_constraints WHERE CONSTRAINT_SCHEMA=DATABASE() AND CONSTRAINT_NAME=? AND CONSTRAINT_TYPE='FOREIGN KEY'" fk]
+     :result-set-fn first)
+    false))
+
 
 (defn- table-exists?
   [db table]
@@ -199,12 +209,13 @@
   (when-not (vector? commands)
     (log/error "Values for `up` and `down` must be vectors of commands"))
   (try
-    (let [sql-commands (into [] (mapcat generate-sql commands))]
-      (doseq [cmd sql-commands]
-        (log/info "Executing: " cmd)
-        (jdbc/db-do-commands (db-spec db) cmd))
-      (log/info "Updating version to: " version)
-      (jdbc/db-do-commands (db-spec db) (update-schema-version version-table version)))))
+    (binding [*db* db]
+      (let [sql-commands (into [] (mapcat generate-sql commands))]
+        (doseq [cmd sql-commands]
+          (log/info "Executing: " cmd)
+          (jdbc/db-do-commands (db-spec db) cmd))
+        (log/info "Updating version to: " version)
+        (jdbc/db-do-commands (db-spec db) (update-schema-version version-table version))))))
 
 (defn- validate-commands
   [commands]

--- a/src/tern/version.clj
+++ b/src/tern/version.clj
@@ -1,2 +1,2 @@
 (ns tern.version)
-(def tern-version "0.3.0")
+(def tern-version "0.4.0")

--- a/test/tern/mysql_test.clj
+++ b/test/tern/mysql_test.clj
@@ -17,4 +17,11 @@
 (expect ["INSERT INTO foo VALUES (1,2,\"foo\"),(3,4,\"bar\")"]
         (generate-sql {:insert-into :foo :values [[1 2 "foo"] [3 4 "bar"]]}))
 
+(expect ["IF NOT EXISTS (SELECT 1 FROM information_schema.TABLE_CONSTRAINTS WHERE CONSTRAINT_SCHEMA=DATABASE() AND CONSTRAINT_NAME='fk_foo_bar' AND CONSTRAINT_TYPE='FOREIGN KEY') THEN ALTER TABLE foo ADD CONSTRAINT fk_foo_bar FOREIGN KEY (bar_id) REFERENCES bar(id)"]
+        (generate-sql {:alter-table :foo :add-constraints [[:fk_foo_bar "(bar_id) REFERENCES bar(id)"]]}))
+
+(expect ["IF EXISTS (SELECT 1 FROM information_schema.TABLE_CONSTRAINTS WHERE CONSTRAINT_SCHEMA=DATABASE() AND CONSTRAINT_NAME='fk_foo_bar' AND CONSTRAINT_TYPE='FOREIGN KEY') THEN ALTER TABLE foo DROP FOREIGN KEY fk_foo_bar"]
+        (generate-sql {:alter-table :foo :drop-constraints [:fk_foo_bar]}))
+
+
 

--- a/test/tern/mysql_test.clj
+++ b/test/tern/mysql_test.clj
@@ -17,11 +17,10 @@
 (expect ["INSERT INTO foo VALUES (1,2,\"foo\"),(3,4,\"bar\")"]
         (generate-sql {:insert-into :foo :values [[1 2 "foo"] [3 4 "bar"]]}))
 
-(expect ["IF NOT EXISTS (SELECT 1 FROM information_schema.TABLE_CONSTRAINTS WHERE CONSTRAINT_SCHEMA=DATABASE() AND CONSTRAINT_NAME='fk_foo_bar' AND CONSTRAINT_TYPE='FOREIGN KEY') THEN ALTER TABLE foo ADD CONSTRAINT fk_foo_bar FOREIGN KEY (bar_id) REFERENCES bar(id)"]
+(expect ["ALTER TABLE foo ADD CONSTRAINT fk_foo_bar FOREIGN KEY (bar_id) REFERENCES bar(id)"]
         (generate-sql {:alter-table :foo :add-constraints [[:fk_foo_bar "(bar_id) REFERENCES bar(id)"]]}))
 
-(expect ["IF EXISTS (SELECT 1 FROM information_schema.TABLE_CONSTRAINTS WHERE CONSTRAINT_SCHEMA=DATABASE() AND CONSTRAINT_NAME='fk_foo_bar' AND CONSTRAINT_TYPE='FOREIGN KEY') THEN ALTER TABLE foo DROP FOREIGN KEY fk_foo_bar"]
-        (generate-sql {:alter-table :foo :drop-constraints [:fk_foo_bar]}))
+
 
 
 


### PR DESCRIPTION
Allows you to retry a migration that partially fails.  At present, this only allows for retrying migrations for which {:alter-table ... :add-constraint} or {:alter-table ... :drop-constraint} has failed.
