### PR TITLE
Trying to make migrations more idempotent

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject cc.artifice/lein-tern "0.4.1"
+(defproject cc.artifice/lein-tern "0.4.2"
   :description "Migrations as data"
   :url "http://github.com/artifice-cc/lein-tern"
   :license {:name "MIT"

--- a/src/tern/version.clj
+++ b/src/tern/version.clj
@@ -1,2 +1,2 @@
 (ns tern.version)
-(def tern-version "0.4.1")
+(def tern-version "0.4.2")


### PR DESCRIPTION
Doesn't try to drop nonexistent indexes, tables, columns.  Doesn't try to add columns that already exist.
