### PR TITLE
Support creating and altering table options (e.g., ROW_FORMAT)

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject cc.artifice/lein-tern "0.4.3"
+(defproject cc.artifice/lein-tern "0.4.4"
   :description "Migrations as data"
   :url "http://github.com/artifice-cc/lein-tern"
   :license {:name "MIT"

--- a/src/tern/version.clj
+++ b/src/tern/version.clj
@@ -1,2 +1,2 @@
 (ns tern.version)
-(def tern-version "0.4.3")
+(def tern-version "0.4.4")

--- a/test/tern/mysql_test.clj
+++ b/test/tern/mysql_test.clj
@@ -20,7 +20,20 @@
 (expect ["ALTER TABLE foo ADD CONSTRAINT fk_foo_bar FOREIGN KEY (bar_id) REFERENCES bar(id)"]
         (generate-sql {:alter-table :foo :add-constraints [[:fk_foo_bar "(bar_id) REFERENCES bar(id)"]]}))
 
+(expect ["ALTER TABLE foo ROW_FORMAT=Compressed"
+         "ALTER TABLE foo ADD CONSTRAINT fk_foo_bar FOREIGN KEY (bar_id) REFERENCES bar(id)"]
+        (generate-sql {:alter-table :foo
+                       :table-options [{:name "ROW_FORMAT" :value "Compressed"}]
+                       :add-constraints [[:fk_foo_bar "(bar_id) REFERENCES bar(id)"]]}))
 
-
-
+(expect ["CREATE TABLE foo (__placeholder int)"
+         "ALTER TABLE foo ROW_FORMAT=Compressed"
+         "ALTER TABLE foo ADD COLUMN a INT"
+         "ALTER TABLE foo ADD COLUMN b INT"
+         "ALTER TABLE foo ADD PRIMARY KEY (a)"
+         "ALTER TABLE foo DROP COLUMN __placeholder"]
+        (generate-sql {:create-table :foo
+                       :primary-key [:a]
+                       :table-options [{:name "ROW_FORMAT" :value "Compressed"}]
+                       :columns [[:a "INT"] [:b "INT"]]}))
 


### PR DESCRIPTION
We need to be able to migrate character set and table row_format changes:

```
{:up
 [{:alter-table :terms 
   :table-options [{:name "row_format" :value "Compressed}] 
   :character-set { :charset-name "utf8" :collation "utf8_general_ci}}]}
```

This commit adds the ability to alter an existing table, and also adds the ability to provide table options for new tables.  The latter is complicated by the fact that tern uses a very old version of clojure.java.jdbc, wherein it is not possible to pass table-specs to the create-table-ddl function.  There are too many breaking changes in clojure.java.jdbc to adopt a newer version.  So when one requests a new table with a table option, the code generates a table with a single placeholder column (because you can't create a table without columns), then applies the table options, adds the requested columns, constraints, primary keys, and finally drops the placeholder columns.  Whew!  There is a test for this that passes.