### PR TITLE
Add test to avoid creating existing table in MySQL.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject cc.artifice/lein-tern "0.5.1"
+(defproject cc.artifice/lein-tern "0.5.2"
   :description "Migrations as data"
   :url "http://github.com/artifice-cc/lein-tern"
   :license {:name "MIT"

--- a/src/tern/commands.clj
+++ b/src/tern/commands.clj
@@ -4,7 +4,8 @@
             [tern.file            :as f :refer [fname]]
             [tern.implementations :as impl]
             [tern.log             :as log]
-            [tern.migrate         :as migrate]))
+            [tern.migrate         :as migrate]
+            [tern.version         :as tern-version]))
 
 (defn init
   "Creates the table used by `tern` to track versions."
@@ -46,6 +47,12 @@
         from    (db/version impl)
         to      (migrate/version config)
         pending (migrate/pending config from)]
+
+    (log/info "#######################################################")
+    (log/info (format "This is tern version %s" tern-version/tern-version))
+    (log/info "#######################################################")
+    (log/info "")
+    
     (log/info "#######################################################")
     (log/info "Migrating from version" (log/highlight from) "to" (log/highlight to))
     (log/info "#######################################################")

--- a/src/tern/version.clj
+++ b/src/tern/version.clj
@@ -1,2 +1,2 @@
 (ns tern.version)
-(def tern-version "0.5.1")
+(def tern-version "0.5.2")


### PR DESCRIPTION
The create-table option needed to test for whether the table already exists, to avoid a SQL error when reexecuting a migration whose later step failed.
