### PR TITLE
Fix table_exists

### DIFF
--- a/src/tern/mysql.clj
+++ b/src/tern/mysql.clj
@@ -226,7 +226,7 @@
   [db table]
   (jdbc/query
     (db-spec db)
-    ["SELECT 1 FROM information_schema.tables WHERE table_name = ?" table]
+    ["SELECT 1 FROM information_schema.tables WHERE table_schema=database() and table_name = ?" table]
     :result-set-fn first))
 
 (defn- column-exists?


### PR DESCRIPTION
tern.mysql/table-exists? wasn't testing that the table exists in the current table_schema, and was returning true for `users` (in our db) because that table exists in the mysql schema.