### PR TITLE
Fix bugs in plan analysis

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject cc.artifice/lein-tern "0.5.2"
+(defproject cc.artifice/lein-tern "0.5.3"
   :description "Migrations as data"
   :url "http://github.com/artifice-cc/lein-tern"
   :license {:name "MIT"

--- a/src/tern/mysql.clj
+++ b/src/tern/mysql.clj
@@ -92,7 +92,7 @@
                    (not (some (fn [prior]
                                 (and (= table (:alter-table prior))
                                      (some (fn [col] (= col column)) (:drop-columns prior))))
-                              *plan*)))
+                              @*plan*)))
             (do (log/info (format "   * Skipping ADD COLUMN %s.%s because it already exists."
                                   (to-sql-name table) (to-sql-name column)))
                 nil)
@@ -131,7 +131,7 @@
                           (and (= table (:alter-table prior))
                                (some (fn [[cons & specs]] (= cons constraint))
                                      (:drop-constraints prior))))
-                        *plan*))
+                        @*plan*))
             (do
               (log/info "    * Adding constraint " (log/highlight (if constraint constraint "unnamed")))
               (format "ALTER TABLE %s ADD CONSTRAINT %s FOREIGN KEY %s" 
@@ -175,8 +175,8 @@
            (index-exists? *db* (to-sql-name table) (to-sql-name index))
            (not (some (fn [prior]
                         (and (= index (:drop-index prior))
-                             (= table (:on prior)))))
-                      *plan*))
+                             (= table (:on prior))))
+                      @*plan*)))
     (do (log/info (format "   * Skipping CREATE INDEX on table %s name %s because it already exists."
                           (to-sql-name table) (to-sql-name index)))
         nil)

--- a/src/tern/version.clj
+++ b/src/tern/version.clj
@@ -1,2 +1,2 @@
 (ns tern.version)
-(def tern-version "0.5.2")
+(def tern-version "0.5.3")


### PR DESCRIPTION
There were some bugs in the code that attempted to prevent errors in mysql schema updates.  Note that it is now required to specify the table from which an index is being dropped in `:drop-index`:

`{:drop-index :foo_col_idx :on :foo}`

This is to check if the index does currently exist.  In addition, in a 

`[{:drop-index :name :on :table} 
   {:create-index :name :on :table ...}
   ...]` 

case, the code will correctly permit the `:create-index` to go through rather than filtering it out because the index appears to exist when the migration starts.

The change to :drop-index may require some existing migrations to be fixed.