### PR TITLE
Ensure created column in schema_versions has current timestamp

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject cc.artifice/lein-tern "0.5.6"
+(defproject cc.artifice/lein-tern "0.5.7"
   :description "Migrations as data"
   :url "http://github.com/artifice-cc/lein-tern"
   :license {:name "MIT"

--- a/src/tern/mysql.clj
+++ b/src/tern/mysql.clj
@@ -311,7 +311,7 @@
 
 (defn- update-schema-version
   [version-table version]
-  (format "INSERT INTO %s (version) VALUES (%s)"
+  (format "INSERT INTO %s (version,created) VALUES (%s,CURRENT_TIMESTAMP)"
           version-table version))
 
 (defn- run-migration!

--- a/src/tern/version.clj
+++ b/src/tern/version.clj
@@ -1,3 +1,3 @@
 (ns tern.version)
-(def tern-version "0.5.6")
+(def tern-version "0.5.7")
 


### PR DESCRIPTION
There was an issue when creating the schema_versions table in a new version of MySQL.  I now have to explicitly set the created column.

