### PR TITLE
Support H2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ pom.xml.asc
 /.lein-*
 /.nrepl-port
 .DS_Store
+**/*~

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject cc.artifice/lein-tern "0.5.7"
+(defproject cc.artifice/lein-tern "0.5.8"
   :description "Migrations as data"
   :url "http://github.com/artifice-cc/lein-tern"
   :license {:name "MIT"

--- a/src/tern/commands.clj
+++ b/src/tern/commands.clj
@@ -56,8 +56,8 @@
     (log/info "#######################################################")
     (log/info "Migrating from version" (log/highlight from) "to" (log/highlight to))
     (log/info "#######################################################")
-    (doseq [migration pending]
-      (log/info "Processing" (log/filename (fname migration)))
+    (doseq [[index migration] (map-indexed (fn [i m] [i m]) pending)]
+      (log/info "Processing" (log/filename (fname migration)) (format "(%d of %d)" (inc index) (count pending)))
       (migrate/run impl migration))
     (if (seq pending)
       (log/info "Migration complete")

--- a/src/tern/db.clj
+++ b/src/tern/db.clj
@@ -22,7 +22,11 @@
 (defn subname
   "Build the db subname from its component parts"
   [{:keys [host port database] :as db}]
-  (str "//" host ":" port "/" database))
+  (cond (and (not-empty host) (not-empty port))
+        (str "//" host ":" port "/" database)
+        (not-empty host)
+        (str "//" host "/" database)
+        :else database))
 
 (defn db-spec
   "Build a jdbc compatible db-spec from db config."

--- a/src/tern/file.clj
+++ b/src/tern/file.clj
@@ -30,7 +30,13 @@
   (.mkdir (File. migration-dir))
   (doto (generate-name migration-dir name) (spit empty-migration)))
 
-(defn fname
+(defmulti fname (fn [f] (type f)))
+(defmethod fname :default [f] (str f))
+(defmethod fname String [f] f)
+(defmethod fname java.io.File [f] (.getName f))
+(defmethod fname java.nio.file.Path [f] (str (.getFileName f)))
+
+#_(defn fname
   "Wrapper for file.getName() because I am a bad person,
   and can't just leave Clojure's Java interop alone and
   get on with more important things instead."
@@ -47,11 +53,11 @@
   [f]
   (or (second (re-find #"\.([^\.]+)$" (fname f))) ""))
 
-(defn has-exension?
+(defn has-extension?
   "Checks if a file has the given extension."
   [ext f]
   (= ext (extension f)))
 
 (def edn?
   ^{:doc "Checks if a file has the `edn` extension." }
-  (partial has-exension? "edn"))
+  (partial has-extension? "edn"))

--- a/src/tern/h2.clj
+++ b/src/tern/h2.clj
@@ -1,0 +1,429 @@
+(ns tern.h2
+  (:require [tern.db           :refer :all]
+            [tern.log          :as log]
+            [clojure.java.jdbc :as jdbc]
+            [clojure.string    :as s])
+  (:import [java.util Date]
+           [java.sql PreparedStatement Timestamp]))
+
+(declare foreign-key-exists? index-exists? column-exists? table-exists? get-column-definition not-indexable-type?)
+
+(def ^:dynamic *db* nil)
+(def ^:dynamic *plan* nil)
+
+(def ^{:doc "Set of supported commands. Used in `generate-sql` dispatch."
+       :private true}
+  supported-commands
+  #{:create-table :drop-table :alter-table :create-index :drop-index :insert-into :update})
+
+(defn ^:private remove-column-length
+  "Sanitize a column name that might include a length, as these are not supported in H2"
+  [column-name]
+  (let [[_ name length] (re-matches #"(\w+)(:?\(\d+\))?" column-name)]
+    (if (and name length) name column-name)))
+
+(defn ^:private unsupported-column-spec
+  [spec]
+  (let [s (cond (string? spec)
+                spec
+                (keyword? spec)
+                (name spec)
+                (symbol? spec)
+                (name spec)
+                :else (str spec))]
+    (or (re-matches #"(?i)CHARACTER SET .+" s)
+        (re-matches #"(?i)COLLATE .+" s))))
+
+(defn ^:private remove-unsupported-column-specs
+  [specs]
+  (for [spec specs :when (not (unsupported-column-spec spec))]
+    spec))
+   
+(defn generate-pk
+  [{:keys [primary-key] :as command}]
+  (when primary-key
+    (format "PRIMARY KEY (%s)" (to-sql-list primary-key))))
+
+(defn generate-constraints
+  [{:keys [constraints] :as command}]
+  (let [fks 
+        (when constraints
+          (for [[constraint & specs] constraints]
+            (do
+              (format "CONSTRAINT %s FOREIGN KEY %s"
+                      (to-sql-name constraint)
+                      (s/join " " specs)))))]
+    (when fks (map (fn [fk] [fk]) fks))))
+
+
+(defn generate-options
+  [table-options]
+  (when (not-empty table-options)
+    (s/join ", "
+            (for [option table-options]
+              (format "%s=%s" (:name option) (:value option))))))
+
+(defmulti generate-sql
+  (fn [c] (some supported-commands (keys c))))
+
+(defmethod generate-sql
+  :create-table
+  [{table :create-table columns :columns table-options :table-options :as command}]
+  (log/info " - Creating table" (log/highlight (name table)))
+  (let [constraints (generate-constraints command)
+        table-spec (generate-options table-options)
+        pk (generate-pk command)]
+    (if (and *db*
+             (table-exists? *db* (to-sql-name table))
+             (not (some (fn [prior] (= prior {:drop-table table})) @*plan*)))
+      (do (log/info (format "  * Skipping CREATE TABLE %s because it already exists." (to-sql-name table)))
+          nil)
+      (if (not-empty table-spec)
+        (concat
+         (apply conj
+                (generate-sql {:create-table table :columns [[:__placeholder "int"]]})
+                (generate-sql {:alter-table table
+                               :table-options table-options
+                               :add-columns columns
+                               :add-constraints (:constraints command)}))
+         (apply conj
+                [(format "ALTER TABLE %s ADD %s" (to-sql-name table) pk)]
+                (generate-sql {:alter-table table
+                               :drop-columns [:__placeholder]})))
+        (let [sanitized-columns
+              (for [[name & opts] columns]
+                (cons name (filter (comp not unsupported-column-spec) opts)))]
+          [(if pk
+             (apply jdbc/create-table-ddl table (apply conj sanitized-columns [pk] constraints))
+             (if constraints
+               (apply jdbc/create-table-ddl table (apply conj sanitized-columns constraints))
+               (apply jdbc/create-table-ddl table sanitized-columns)))])))))
+
+(defmethod generate-sql
+  :drop-table
+  [{table :drop-table}]
+  (log/info " - Dropping table" (log/highlight (name table)))
+  [(jdbc/drop-table-ddl table)])
+
+(defmethod generate-sql
+  :alter-table
+  [{table :alter-table add-columns :add-columns drop-columns :drop-columns modify-columns :modify-columns
+    add-constraints :add-constraints  drop-constraints :drop-constraints
+    table-options :table-options character-set :character-set}]
+  (log/info " - Altering table" (log/highlight (name table)))
+  (let [additions
+        (for [[column & specs] add-columns]
+          (if (and *db*
+                   (column-exists? *db* (to-sql-name table) (to-sql-name column))
+                   (not (some (fn [prior]
+                                (and (= table (:alter-table prior))
+                                     (some (fn [col] (= col column)) (:drop-columns prior))))
+                              @*plan*)))
+            (do (log/info (format "   * Skipping ADD COLUMN %s.%s because it already exists."
+                                  (to-sql-name table) (to-sql-name column)))
+                nil)
+            (do (log/info "    * Adding column" (log/highlight (name column)))
+                (format "ALTER TABLE %s ADD COLUMN %s %s"
+                        (to-sql-name table)
+                        (to-sql-name column)
+                        (s/join " " (remove-unsupported-column-specs specs))))))
+        removals
+        (for [column drop-columns]
+          ;; Note: No test for prior alter table/add column or create table w/ column
+          ;; because frankly it would not make sense in a single migration to create
+          ;; a table column and then immediately drop it.
+          (if (or (not *db*)
+                  (column-exists? *db* (to-sql-name table) (to-sql-name column)))
+            (do (log/info "    * Dropping column" (log/highlight (name column)))
+                (format "ALTER TABLE %s DROP COLUMN %s"
+                        (to-sql-name table)
+                        (to-sql-name column)))
+            (do (log/info "   * Skipping DROP COLUMN %s.%s because that column does not exist."
+                          (to-sql-name table) (to-sql-name column))
+                nil)))
+        modifications
+        (for [[column & specs] modify-columns]
+          (do (log/info "    * Modifying column" (log/highlight (name column)))
+              (format "ALTER TABLE %s MODIFY COLUMN %s %s"
+                      (to-sql-name table)
+                      (to-sql-name column)
+                      (s/join " " (remove-unsupported-column-specs specs)))))
+        new-constraints
+        (for [[constraint & specs] add-constraints]
+          (if (or (not *db*)
+                  (not (foreign-key-exists? *db* (to-sql-name constraint)))
+                  (some (fn [prior]
+                          ;; Did we previously drop the constraint?
+                          (and (= table (:alter-table prior))
+                               (some (fn [[cons & specs]] (= cons constraint))
+                                     (:drop-constraints prior))))
+                        @*plan*))
+            (do
+              (log/info "    * Adding constraint " (log/highlight (if constraint constraint "unnamed")))
+              (format "ALTER TABLE %s ADD CONSTRAINT %s FOREIGN KEY %s" 
+                      (to-sql-name table)
+                      (to-sql-name constraint)
+                      (s/join  " " specs)))
+            (log/info "    * Skipping adding constraint " (log/highlight (if constraint constraint "unnamed"))
+                      " because it already exists")))
+       old-constraints
+       (for [constraint drop-constraints]
+         ;; As with drop-column, we are not checking here for add constraint followed by drop constraint
+         ;; in the same migration.  Wouldn't make sense.
+         (if (or (not *db*)
+                 (foreign-key-exists? *db* (to-sql-name constraint)))
+           (do
+             (log/info "    * Removing constraint " (log/highlight constraint))
+             (format "ALTER TABLE %s DROP FOREIGN KEY %s",
+                     (to-sql-name table)
+                     (to-sql-name constraint)))
+           (log/info "   * Skipping removing constraint " (log/highlight constraint) " because it does not exist")))
+        options
+        (do (log/info "   * Skipping options " table-options " because H2 does not support them")
+            [])
+        charset
+        (when character-set
+          (log/info "   * Skipping convert to character set because H2 does not support it.")
+          [])]
+    (doall (filter identity (concat options charset old-constraints removals additions modifications new-constraints)))))
+
+(defmethod generate-sql
+  :create-index
+  [{index   :create-index
+    table   :on
+    columns :columns
+    unique  :unique}]
+  (if (and *db*
+           (index-exists? *db* (to-sql-name table) (to-sql-name index))
+           (not (some (fn [prior]
+                        (and (= index (:drop-index prior))
+                             (= table (:on prior))))
+                      @*plan*)))
+    (do (log/info (format "   * Skipping CREATE INDEX on table %s name %s because it already exists."
+                          (to-sql-name table) (to-sql-name index)))
+        nil)
+    (let [columns (map (comp remove-column-length to-sql-name) columns)
+          indexable-columns (filter (fn [column]
+                                      (let [type (or (:type_name (get-column-definition *db* (to-sql-name table) column))
+                                                     (some (fn [prior]
+                                                             (cond (= table (:create-table prior))
+                                                                   (some (fn [col]
+                                                                           (and (= (to-sql-name (first col)) column)
+                                                                                (second col)))
+                                                                         (:columns prior))
+                                                                   (= table (:alter-table prior))
+                                                                   (some (fn [col]
+                                                                           (and (= (to-sql-name (first col)) column)
+                                                                                (second col)))
+                                                                         (:add-columns prior))))
+                                                           @*plan*))]
+                                        (not (not-indexable-type? type))))
+                                    columns)]
+      (if (empty? indexable-columns)
+        (do (log/info (format "   * Skipping creating index %s because none of the specified columns are indexable." index))
+            [])
+        (do (log/info " - Creating" (if unique "unique" "") "index" (log/highlight (name index)) "on" (log/highlight (name table)))
+            [(format "CREATE %s INDEX %s ON %s (%s)"
+                     (if unique "UNIQUE" "")
+                     (to-sql-name index)
+                     (to-sql-name table)
+                     (s/join ", " indexable-columns))])))))
+
+(defmethod generate-sql
+  :drop-index
+  [{index :drop-index table :on}]
+  ;; As with drop-column, we are not checking here for create index followed by drop index
+  ;; in the same migration.  Wouldn't make sense.
+  (if (or (not *db*) (index-exists? *db* (to-sql-name table) (to-sql-name index)))
+    (do (log/info " - Dropping index" (log/highlight (name index)))
+        [(format "DROP INDEX %s ON %s" (to-sql-name index) (to-sql-name table))])
+    (do (log/info (format "   * Skipping DROP INDEX on table %s index %s because that index does not exist."
+                          table index))
+        nil)))
+
+(defmethod generate-sql
+  :insert-into
+  [{table :insert-into values :values query :query}]
+  (log/info " - Inserting into" (log/highlight (name table)))
+  (cond (not-empty values)
+        [(format "INSERT INTO %s VALUES %s" (to-sql-name table)
+                 (s/join "," (map (fn [vals] (format "(%s)" (s/join ","
+                                                                    (map #(if (string? %)
+                                                                            (str "'" % "'")
+                                                                            (pr-str %))
+                                                                         vals))))
+                                  values)))]
+        (not-empty query)
+        [(format "INSERT INTO %s %s" (to-sql-name table) query)]
+        :else (throw (Exception. ":insert-into must contain a non-empty :values or :query key"))))
+
+(defmethod generate-sql
+  :update
+  [{update-query :update h2-version :h2}]
+  (log/info " - Updating the database" (log/highlight update-query))
+  (let [command (or (not-empty h2-version) (not-empty update-query))]
+    (cond (not-empty command)
+          [command]
+          :else (throw (Exception. ":update must contain a non-empty update statement or :h2 version of the same statement")))))
+
+(defmethod generate-sql
+  :default
+  [command]
+  (log/error "Don't know how to process command:" (log/highlight (pr-str command)))
+  (System/exit 1))
+
+(defn- database-exists?
+  [db]
+  (jdbc/query
+    (db-spec db "h2")
+    ["SELECT 1 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = ?" (:database db)]
+    :result-set-fn first))
+
+(defn- foreign-key-exists?
+  [db fk]
+  (if db
+    (jdbc/query
+     (db-spec db)
+     ["SELECT 1 from information_schema.table_constraints WHERE CONSTRAINT_SCHEMA=SCHEMA() AND CONSTRAINT_NAME=? AND CONSTRAINT_TYPE='FOREIGN KEY'"
+      (s/upper-case fk)]
+     :result-set-fn first)
+    false))
+
+(defn- index-exists?
+  [db table index]
+  (if db
+    (do 
+      ;;(log/info (format "   * Testing whether table %s has index %s" table index))
+      (jdbc/query
+       (db-spec db)
+       ["SELECT 1 from information_schema.indexes WHERE TABLE_SCHEMA=SCHEMA() AND TABLE_NAME=? AND INDEX_NAME=?"
+        (s/upper-case table)
+        (s/upper-case index)]
+       :result-set-fn first))
+    false))
+
+(defn- table-exists?
+  [db table]
+  (jdbc/query
+    (db-spec db)
+    ["SELECT 1 FROM information_schema.tables WHERE table_schema=SCHEMA() and table_name = ?" (s/upper-case table)]
+    :result-set-fn first))
+
+(defn not-indexable-type?
+  [datatype]
+  (#{"CLOB" "TINYTEXT" "TEXT" "MEDIUMTEXT" "LONGTEXT" "NTEXT" "NCLOB" "BLOB" "TINYBLOB" "MEDIUMBLOB" "LONGBLOB" "IMAGE" "OID"}
+   (s/upper-case (name datatype))))
+
+(defn- get-column-definition
+  [db table column]
+  (jdbc/query
+   (db-spec db)
+   ["SELECT * from information_schema.columns where table_schema=SCHEMA() and table_name=? and column_name=?"
+    (s/upper-case table)
+    (s/upper-case column)
+    ]
+   :result-set-fn first
+   ))
+
+(defn- column-exists?
+  [db table column]
+  (jdbc/query
+   (db-spec db)
+   ["SELECT 1 from information_schema.columns where table_schema=SCHEMA() and table_name=? and column_name=?"
+    (s/upper-case table)
+    (s/upper-case column)]
+   :result-set-fn first))
+
+(defn- create-database
+  [db]
+  (jdbc/db-do-commands
+    (db-spec db "h2") false
+    (format "CREATE DATABASE %s" (:database db))))
+
+(defn- create-version-table
+  [db version-table]
+  (apply jdbc/db-do-commands
+         (db-spec db)
+         (generate-sql
+           {:create-table version-table
+            :columns [[:version "VARCHAR(14)" "NOT NULL"]
+                      [:created "BIGINT"      "NOT NULL"]]})))
+
+(defn- psql-error-message
+  [e]
+  (s/replace (.getMessage e) #"^(FATAL|ERROR): " ""))
+
+(defn- batch-update-error-message
+  [e]
+  (s/replace (.getMessage (.getNextException e)) #"^(FATAL|ERROR): " ""))
+
+(defn- init-db!
+  [{:keys [db version-table]}]
+  (try
+    (when-not (database-exists? db)
+      (create-database db)
+      (log/info "Created database:" (:database db)))
+    (when-not (table-exists? db version-table)
+      (create-version-table db version-table)
+      (log/info "Created table:   " version-table))))
+
+(defn- get-version
+  [{:keys [db version-table]}]
+  (let [dbspec (db-spec db)
+        connection (jdbc/get-connection dbspec)]
+    (try
+      (jdbc/query
+       dbspec
+       [(format "SELECT version FROM %s
+                  ORDER BY version DESC
+                  LIMIT 1" version-table)]
+       :row-fn :version
+       :result-set-fn first))))
+
+(defn- update-schema-version
+  [version-table version]
+  (format "INSERT INTO %s (version,created) VALUES (%s,CURRENT_TIMESTAMP)"
+          version-table version))
+
+(defn- run-migration!
+  [{:keys [db version-table]} version commands]
+  (when-not (vector? commands)
+    (log/error "Values for `up` and `down` must be vectors of commands"))
+  (try
+    (binding [*db* db
+              *plan* (atom [])]
+      #_(doseq [column (jdbc/query (db-spec db)
+                                 ["select * from information_schema.columns where table_schema=SCHEMA() and table_name=? and column_name=?"
+                                  "TAXNODES" "PATH"])]
+        (println (pr-str column)))
+      (let [sql-commands (into [] (mapcat
+                                   (fn [command]
+                                     (let [sql (generate-sql command)]
+                                       (swap! *plan* concat [command])
+                                       sql))
+                                   commands))]
+        (doseq [cmd sql-commands]
+          (log/info "Executing: " cmd)
+          (jdbc/db-do-commands (db-spec db) cmd))
+        (log/info "Updating version to: " version)
+        (jdbc/db-do-commands (db-spec db) (update-schema-version version-table version))))))
+
+(defn- validate-commands
+  [commands]
+  (cond (and (vector? commands)
+             (every? map? commands)) commands
+        (map? commands) [vec commands]
+        nil nil
+        :else (do
+                (log/error "The values for `up` and `down` must be either a map or a vector of maps.")
+                (System/exit 1))))
+
+(defrecord H2Migrator
+  [config]
+  Migrator
+  (init[this]
+    (init-db! config))
+  (version [this]
+    (or (get-version config) "0"))
+  (migrate [this version commands]
+    (run-migration! config version (validate-commands commands))))

--- a/src/tern/implementations.clj
+++ b/src/tern/implementations.clj
@@ -1,12 +1,15 @@
 (ns tern.implementations
   (:require [tern.postgresql :as postgresql]
             [tern.mysql      :as mysql]
+            [tern.h2         :as h2]
             [tern.log        :as log]))
 
 (def ^{:doc "A map of available migrator implementations."
        :private true}
   constructor-store
-  (atom {:postgresql postgresql/->PostgresqlMigrator :mysql mysql/->MysqlMigrator}))
+  (atom {:postgresql postgresql/->PostgresqlMigrator
+         :mysql mysql/->MysqlMigrator
+         :h2 h2/->H2Migrator}))
 
 (defn register!
   "Register a new tern implementation. This function
@@ -24,5 +27,5 @@
   (if-let [new-impl (@constructor-store (keyword subprotocol))]
     (new-impl config)
     (do
-      (log/error "Sorry, support for" subprotocol "is not implemented yet.")
+      (log/error "Sorry, support for" (pr-str subprotocol) "is not implemented yet.")
       (System/exit 1))))

--- a/src/tern/version.clj
+++ b/src/tern/version.clj
@@ -1,3 +1,3 @@
 (ns tern.version)
-(def tern-version "0.5.7")
+(def tern-version "0.5.8")
 


### PR DESCRIPTION
Now supports migrating databases in H2.  Handles almost all of the cases that MySQL handles.  H2 doesn't support charsets or table options, so these are ignored.  Is smart about changes to foreign keys--anonymous FKs created in column definitions are automatically removed when defining explicit FKs over the same FK/PK pair.  This appears to be something MySQL does by itself, but H2 doesn't.
