### PR TITLE
Combine add and drop column in H2 and MySQL

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject cc.artifice/lein-tern "0.5.9"
+(defproject cc.artifice/lein-tern "0.5.10"
   :description "Migrations as data"
   :url "http://github.com/artifice-cc/lein-tern"
   :license {:name "MIT"

--- a/src/tern/version.clj
+++ b/src/tern/version.clj
@@ -1,3 +1,3 @@
 (ns tern.version)
-(def tern-version "0.5.9")
+(def tern-version "0.5.10")
 

--- a/test/tern/mysql_test.clj
+++ b/test/tern/mysql_test.clj
@@ -20,16 +20,13 @@
 (expect ["ALTER TABLE foo ADD CONSTRAINT fk_foo_bar FOREIGN KEY (bar_id) REFERENCES bar(id)"]
         (generate-sql {:alter-table :foo :add-constraints [[:fk_foo_bar "(bar_id) REFERENCES bar(id)"]]}))
 
-(expect ["ALTER TABLE foo ROW_FORMAT=Compressed"
-         "ALTER TABLE foo ADD CONSTRAINT fk_foo_bar FOREIGN KEY (bar_id) REFERENCES bar(id)"]
+(expect ["ALTER TABLE foo ROW_FORMAT=Compressed, ADD CONSTRAINT fk_foo_bar FOREIGN KEY (bar_id) REFERENCES bar(id)"]
         (generate-sql {:alter-table :foo
                        :table-options [{:name "ROW_FORMAT" :value "Compressed"}]
                        :add-constraints [[:fk_foo_bar "(bar_id) REFERENCES bar(id)"]]}))
 
 (expect ["CREATE TABLE foo (__placeholder int)"
-         "ALTER TABLE foo ROW_FORMAT=Compressed"
-         "ALTER TABLE foo ADD COLUMN a INT"
-         "ALTER TABLE foo ADD COLUMN b INT"
+         "ALTER TABLE foo ROW_FORMAT=Compressed, ADD COLUMN a INT, ADD COLUMN b INT"
          "ALTER TABLE foo ADD PRIMARY KEY (a)"
          "ALTER TABLE foo DROP COLUMN __placeholder"]
         (generate-sql {:create-table :foo


### PR DESCRIPTION
For large tables, speed up migration when multiple add and drop columns are involved in one migration spec.  
