### PR TITLE
Support adding and dropping primary key from tables in MySQL and H2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ pom.xml.asc
 /.nrepl-port
 .DS_Store
 **/*~
+**/#*
+**/.#*

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject cc.artifice/lein-tern "0.5.10"
+(defproject cc.artifice/lein-tern "0.6.0"
   :description "Migrations as data"
   :url "http://github.com/artifice-cc/lein-tern"
   :license {:name "MIT"

--- a/src/tern/h2.clj
+++ b/src/tern/h2.clj
@@ -326,9 +326,9 @@
 (defn- database-exists?
   [db]
   (jdbc/query
-    (db-spec db)
-    ["SELECT 1 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = ?" (:schema db "PUBLIC")]
-    :result-set-fn first))
+   (db-spec db)
+   ["SELECT 1 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = ?" (:schema db "PUBLIC")]
+   :result-set-fn first))
 
 (defn get-matching-foreign-keys
   [db fktable fkcolumn pktable pkcolumn]

--- a/src/tern/mysql.clj
+++ b/src/tern/mysql.clj
@@ -83,6 +83,7 @@
   :alter-table
   [{table :alter-table add-columns :add-columns drop-columns :drop-columns modify-columns :modify-columns
     add-constraints :add-constraints  drop-constraints :drop-constraints
+    primary-key :primary-key
     table-options :table-options character-set :character-set}]
   (log/info " - Altering table" (log/highlight (name table)))
   (let [additions
@@ -121,6 +122,10 @@
               (format "MODIFY COLUMN %s %s"
                       (to-sql-name column)
                       (s/join " " specs))))
+        primary-key-constraints
+        (if primary-key
+          [(generate-pk {:primary-key primary-key})]
+          [])
         new-constraints
         (filter identity
                 (for [[constraint & specs] add-constraints]
@@ -171,7 +176,7 @@
     [(format "ALTER TABLE %s %s"
              (to-sql-name table)
              (s/join ", "
-                     (concat options charset old-constraints removals additions modifications new-constraints)))]))
+                     (concat options charset old-constraints removals additions modifications primary-key-constraints new-constraints)))]))
 
 (defmethod generate-sql
   :create-index

--- a/src/tern/version.clj
+++ b/src/tern/version.clj
@@ -1,3 +1,3 @@
 (ns tern.version)
-(def tern-version "0.5.10")
+(def tern-version "0.6.0")
 


### PR DESCRIPTION
Support adding and dropping primary keys from tables in H2 and MySQL:
```
{:up
 [{:alter-table :docmetadata
   :modify-columns [["id" "int(11)" "not null"]]}
  {:alter-table :docmetadata
   :drop-constraints [:primary-key]}
  {:alter-table :docmetadata
   :modify-columns [["id" "int(11)" "null"]]}]
 :down
 [{:alter-table :docmetadata
   :modify-columns [["id" "int(11)" "not null" "auto_increment"]]
   :primary-key ["id"]}]}
```